### PR TITLE
Make order and request ID generation methods public

### DIFF
--- a/Sources/JuspayKit/Refund/RefundRoutes.swift
+++ b/Sources/JuspayKit/Refund/RefundRoutes.swift
@@ -49,11 +49,11 @@ public struct JuspayRefundRoutes: RefundRoutes {
         let path = "orders/\(orderId)/refunds"
         var body = "unique_request_id=\(refund.uniqueRequestId)&amount=\(refund.amount)"
         body = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? body
-
+        
         var _headers = headers
         _headers.add(name: "Content-Type", value: "application/x-www-form-urlencoded")
         _headers.add(name: "version", value: DateFormatter.localizedString(from: Date(), dateStyle: .short, timeStyle: .none))
-
+        
         return try await apiHandler.send(method: .POST, path: path, body: .string(body), headers: _headers)
     }
 }

--- a/Sources/JuspayKit/Session/SessionRoutes.swift
+++ b/Sources/JuspayKit/Session/SessionRoutes.swift
@@ -37,17 +37,9 @@ public struct JuspaySessionRoutes: SessionRoutes {
     /// - Returns: A `SessionResponse` object containing the response from the session creation request.
     /// - Throws: An error if the JSON encoding fails, if the network request fails, or if the API returns an error.
     public func create(session: Session) async throws -> SessionResponse {
-        do {
-            let body = try JSONEncoder().encode(session)
-            var _headers = headers
-            _headers.add(name: "Content-Type", value: "application/json")
-            return try await apiHandler.send(method: .POST, path: "session", body: .data(body), headers: _headers)
-        } catch let error as JuspayError {
-            // Handle Juspay-specific errors
-            throw error
-        } catch {
-            // Handle other errors
-            throw error
-        }
+        let body = try JSONEncoder().encode(session)
+        var _headers = headers
+        _headers.add(name: "Content-Type", value: "application/json")
+        return try await apiHandler.send(method: .POST, path: "session", body: .data(body), headers: _headers)
     }
 }

--- a/Sources/JuspayKit/Util/JuspayError.swift
+++ b/Sources/JuspayKit/Util/JuspayError.swift
@@ -6,11 +6,11 @@ public struct JuspayError: Error, Codable, Sendable {
     /// A short string indicating the error code reported.
     public var errorCode: String?
     /// A human-readable message providing more details about the error.
-    public var errorMessage: String
+    public var errorMessage: String?
     /// The status ID of the error.
-    public var statusId: Int
+    public var statusId: Int?
     /// Additional information about the error.
-    public var errorInfo: ErrorInfo
+    public var errorInfo: ErrorInfo?
     
     public var localizedDescription: String {
         return errorMessage

--- a/Sources/JuspayKit/Util/JuspayError.swift
+++ b/Sources/JuspayKit/Util/JuspayError.swift
@@ -13,7 +13,7 @@ public struct JuspayError: Error, Codable, Sendable {
     public var errorInfo: ErrorInfo?
     
     public var localizedDescription: String {
-        return errorMessage
+        return errorMessage ?? "Unknown error"
     }
 }
 

--- a/Sources/JuspayKit/Util/Order+Ext.swift
+++ b/Sources/JuspayKit/Util/Order+Ext.swift
@@ -13,7 +13,7 @@ extension Order {
     ///
     /// - Parameter length: The length of the order ID to generate. The default value is 20.
     /// - Returns: A randomly generated order ID string, or `nil` if the specified length is out of the valid range.
-    static func generateOrderID(length: Int = 20) -> String? {
+    public static func generateOrderID(length: Int = 20) -> String? {
         guard (2...20).contains(length) else { return nil }
         
         var orderID = "O"

--- a/Sources/JuspayKit/Util/Refund+Ext.swift
+++ b/Sources/JuspayKit/Util/Refund+Ext.swift
@@ -9,7 +9,7 @@ extension RefundRequest {
     /// Special characters are avoided to ensure compatibility with various gateways and aggregators.
     ///
     /// - Returns: A randomly generated unique request ID string of 20 characters, starting with 'R'.
-    static func generateUniqueRequestID() -> String {
+    public static func generateUniqueRequestID() -> String {
         let characters = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
         var uniqueRequestID = "R"
         var lastChar: Character?


### PR DESCRIPTION
This PR makes `generateOrderID` and `generateUniqueRequestID` methods publicly accessible to improve flexibility in external usage.