### PR TITLE
Update Order Retrieval to Include Customer ID

### DIFF
--- a/Sources/JuspayKit/Orders/OrderRoutes.swift
+++ b/Sources/JuspayKit/Orders/OrderRoutes.swift
@@ -13,7 +13,7 @@ public protocol OrderRoutes: JuspayAPIRoute {
     /// - Returns: An `Order` object representing the retrieved order.
     ///
     /// - Throws: An error if the order retrieval fails or if there's a network issue.
-    func retrieve(orderId: String) async throws -> Order
+    func retrieve(orderId: String, customerId: String) async throws -> Order
 
     /// Creates a new order in the Juspay system.
     ///
@@ -50,13 +50,9 @@ public struct JuspayOrderRoutes: OrderRoutes {
     /// - Returns: An `Order` object representing the retrieved order.
     ///
     /// - Throws: An error if the order retrieval fails or if there's a network issue.
-    public func retrieve(orderId: String) async throws -> Order {
+    public func retrieve(orderId: String, customerId: String) async throws -> Order {
         var _headers = headers
-        let currentDate = Date()
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        let formattedDate = dateFormatter.string(from: currentDate)
-        _headers.add(name: "version", value: formattedDate)
+        _headers.add(name: "x-routing-id", value: customerId)
         return try await apiHandler.send(method: .GET, path: "orders/\(orderId)", headers: _headers)
     }
 

--- a/Tests/JuspayKitTests/JuspayKitTests.swift
+++ b/Tests/JuspayKitTests/JuspayKitTests.swift
@@ -48,9 +48,15 @@ struct JuspayKitTests {
         #expect(session != nil)
     }
 
+    @Test("List all payment methods")
+    func listPaymentMethods() async throws {
+        let paymentMethods = try await juspayClient.paymentMethods.list()
+        #expect(paymentMethods != nil)
+    }
+
     @Test("Retrieve an order")
     func retrieveOrder() async throws {
-        let order = try await juspayClient.orders.retrieve(orderId: "OiVWluhiNXAQtR10BQaK")
+        let order = try await juspayClient.orders.retrieve(orderId: "OBug0anmAxDG2ncPhBsA", customerId: "4C2AD8F11484CE")
         #expect(order != nil)
     }
 


### PR DESCRIPTION
As per the recent updates in the Juspay API, we need to enhance the order retrieval process to include a `customerId` parameter. This will improve the accuracy of order retrieval and ensure that the correct session is maintained.

## Headers

- **x-merchantid***  
  - **Type:** `String`  
  - **Required:** Yes  
  - **Description:** Merchant ID provided by Juspay  
  - **Example:** `merchant-id`

- **Content-Type**  
  - **Type:** `String`  
  - **Value:** `application/x-www-form-urlencoded`

- **x-routing-id***  
  - **Type:** `String`  
  - **Required:** Yes  
  - **Description:** Merchant’s session is tied to the first API call made to start the payment. Passing the `customer_id` as `x-routing-id` ensures the session remains consistent.  
  - **Note:** Session is tied to `x-routing-id`, so the merchant must use the same `x-routing-id` for all API calls in the same session.

## Updated API Example

### Request

**Endpoint:**  
`GET /orders/{orderId}`

**Headers:**
```http
x-merchantid: merchant-id
x-routing-id: customer-id
Content-Type: application/x-www-form-urlencoded
```

**Parameters:**  
- **orderId** (String): The ID of the order to retrieve.  
- **customerId** (String): The ID of the customer associated with the session.

### Example Usage
```swift
let orderId = "OBug0anmAxDG2ncPhBsA"
let customerId = "4C2AD8F11484CE"

let order = try await juspayClient.orders.retrieve(orderId: orderId, customerId: customerId)
```

## Changes Made

1. Enhanced the `retrieve(orderId:)` method in `OrderRoutes` to accept a `customerId` parameter.
2. Updated the `JuspayOrderRoutes` implementation to include the `customerId` as part of the request.
3. Added a test case for listing all payment methods to improve test coverage.