### PR TITLE
Update dependencies and simplify API request handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.3.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.23.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.24.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
     ],
     targets: [

--- a/Sources/JuspayKit/Core/APIHandler.swift
+++ b/Sources/JuspayKit/Core/APIHandler.swift
@@ -103,25 +103,17 @@ actor JuspayAPIHandler {
             "x-merchantid": merchantId,
             "Content-Type": "application/x-www-form-urlencoded",
         ]
-        let authString = "\(apiKey):".data(using: .utf8)!.base64EncodedString()
-        _headers.add(name: "Authorization", value: "Basic \(authString)")
-
+    
         headers.forEach { _headers.replaceOrAdd(name: $0.name, value: $0.value) }
 
         var request = HTTPClientRequest(url: "\(baseURL)\(path)?\(query)")
         request.headers = _headers
+        request.setBasicAuth(username: apiKey, password: "")
         request.method = method
         request.body = body
-
+        
         let response = try await httpClient.execute(request, timeout: .seconds(60))
         let responseData = try await response.body.collect(upTo: .max)
-
-//        // Debug print the response data in human readable format
-//        if let responseString = responseData.getString(at: responseData.readerIndex, length: responseData.readableBytes) {
-//            print("Response Data: \(responseString)")
-//        } else {
-//            print("Failed to decode response data to string")
-//        }
 
         guard response.status == .ok else {
             let error = try decoder.decode(JuspayError.self, from: responseData)


### PR DESCRIPTION
- Bump async-http-client dependency version from 1.23.0 to 1.24.0 in Package.swift.
- Refactor APIHandler to use setBasicAuth for authorization, improving code clarity.
- Remove commented-out debug print statements to clean up the code.

These changes enhance the package's dependency management and streamline the API request process.